### PR TITLE
Set modification times when unzipping archives

### DIFF
--- a/src/main/java/org/jboss/vfs/VFSUtils.java
+++ b/src/main/java/org/jboss/vfs/VFSUtils.java
@@ -879,6 +879,7 @@ public class VFSUtils {
                     } finally {
                         VFSUtils.safeClose(is);
                     }
+                    current.setLastModified(zipEntry.getTime());
                 }
             }
         } finally {


### PR DESCRIPTION
If times are not set using the values stores on the zip file, everytime
JBoss AS is started all the contents of WAR files has new modification
times, breaking caching behaviour of browsers sice all files are always
new
