### PR TITLE
AS7-1288 fix NPE when no executor has been provided to TempFileProvider

### DIFF
--- a/src/main/java/org/jboss/vfs/TempFileProvider.java
+++ b/src/main/java/org/jboss/vfs/TempFileProvider.java
@@ -147,8 +147,12 @@ public final class TempFileProvider implements Closeable {
 
         public void run() {
             if (VFSUtils.recursiveDelete(root) == false) {
-                log.tracef("Failed to delete root (%s), retrying in 30sec.", root);
-                executor.schedule(this, 30L, TimeUnit.SECONDS);
+                if (executor != null) {
+                    log.tracef("Failed to delete root (%s), retrying in 30sec.", root);
+                    executor.schedule(this, 30L, TimeUnit.SECONDS);
+                } else {
+                    log.tracef("Failed to delete root (%s).", root);
+                }
             }
         }
     }


### PR DESCRIPTION
Ideally a policy decision should be made, is passing a null
ScheduledExecutorService allowed?

If passing null is allowed we never queue for later or provide our own
default executor.

If passing null is not allowed we should provide some way of debugging
the issue, maybe checking executor is non-null on DeleteTask constructor
or log the last 15 stack frame elements with each DeleteTask to split
out some context of the bad code path causing the problem.  The issue
maybe the executor originally provided went away from under us.
