### PR TITLE
Fixing bug #WFLY-1467 by padding the stream to a manifest file with a '\n'

### DIFF
--- a/src/main/java/org/jboss/vfs/VFSUtils.java
+++ b/src/main/java/org/jboss/vfs/VFSUtils.java
@@ -54,8 +54,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.jboss.logging.Logger;
-import org.jboss.vfs.spi.FileSystem;
 import org.jboss.vfs.spi.MountHandle;
+import org.jboss.vfs.util.PaddedManifestStream;
 import org.jboss.vfs.util.PathTokenizer;
 import org.jboss.vfs.util.automount.Automounter;
 
@@ -211,7 +211,7 @@ public class VFSUtils {
     public static Manifest readManifest(VirtualFile manifest) throws IOException {
         if (manifest == null)
             throw new IllegalArgumentException("Null manifest file");
-        InputStream stream = manifest.openStream();
+        InputStream stream = new PaddedManifestStream(manifest.openStream());
         try {
             return new Manifest(stream);
         }

--- a/src/main/java/org/jboss/vfs/util/PaddedManifestStream.java
+++ b/src/main/java/org/jboss/vfs/util/PaddedManifestStream.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.vfs.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Appends a new line char to the stream if it doesn't have one as his last byte.
+ * @author ehsavoie
+ */
+public class PaddedManifestStream extends InputStream {
+
+    private final InputStream realStream;
+    private int previousChar = -1;
+
+    public PaddedManifestStream(InputStream realStream) {
+        this.realStream = realStream;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int value = this.realStream.read();
+        if (value == -1 && previousChar != '\n' && previousChar != -1) {
+            previousChar = '\n';
+            return '\n';
+        }
+        previousChar = value;
+        return value;
+    }
+
+    
+
+}

--- a/src/test/java/org/jboss/test/vfs/VFSUtilsTestCase.java
+++ b/src/test/java/org/jboss/test/vfs/VFSUtilsTestCase.java
@@ -21,10 +21,13 @@
  */
 package org.jboss.test.vfs;
 
-
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.Executors;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 import org.jboss.vfs.TempFileProvider;
 import org.jboss.vfs.VFS;
@@ -34,43 +37,65 @@ import org.junit.Test;
 import org.junit.internal.ArrayComparisonFailure;
 
 /**
- * Test to ensure the functionality of {@link VFSUtils} methods 
+ * Test to ensure the functionality of {@link VFSUtils} methods
  *
  * @author <a href="baileyje@gmail.com">John Bailey</a>
  */
-public class VFSUtilsTestCase extends AbstractVFSTest
-{
-   public VFSUtilsTestCase(String name)
-   {
-      super(name);
-   }
+public class VFSUtilsTestCase extends AbstractVFSTest {
 
-   @Test
-   public void testCopyChildrenRecursive() throws Exception
-   {
-      VirtualFile original = getVirtualFile("/vfs/test/jar1");
-      VirtualFile target = VFS.getChild("/target-jar1"); 
-      Closeable handle = null;
-      try {
-         handle = VFS.mountTemp(target, TempFileProvider.create("test", Executors.newSingleThreadScheduledExecutor()));
-         VFSUtils.copyChildrenRecursive(original, target);
-         assertChildren(original, target);
-         
-      } finally {
-         VFSUtils.safeClose(handle);
-      }
-   }
-   
-   private void assertChildren(VirtualFile original, VirtualFile target) throws ArrayComparisonFailure, IOException {
-      assertEquals("Original and target must have the same numer of children", original.getChildren().size(), target.getChildren().size());
-      for(VirtualFile child : original.getChildren()) {
-         VirtualFile targetChild = target.getChild(child.getName());
-         assertTrue("Target should contain same children as original", targetChild.exists());
-         if(child.isDirectory()) 
-            assertChildren(child, targetChild);
-         else {
-            assertContentEqual(child, targetChild);
-         }
-      }
-   }
+    public VFSUtilsTestCase(String name) {
+        super(name);
+    }
+
+    @Test
+    public void testCopyChildrenRecursive() throws Exception {
+        VirtualFile original = getVirtualFile("/vfs/test/jar1");
+        VirtualFile target = VFS.getChild("/target-jar1");
+        Closeable handle = null;
+        try {
+            handle = VFS.mountTemp(target, TempFileProvider.create("test", Executors.newSingleThreadScheduledExecutor()));
+            VFSUtils.copyChildrenRecursive(original, target);
+            assertChildren(original, target);
+
+        } finally {
+            VFSUtils.safeClose(handle);
+        }
+    }
+
+    @Test
+    public void testReadManifest() throws Exception {
+        VirtualFile correctManifest = getVirtualFile("/vfs/test/manifest/correct.mf");        
+        Manifest manifest = VFSUtils.readManifest(correctManifest);               
+        assertManifest(manifest);
+        VirtualFile incorrectManifest = getVirtualFile("/vfs/test/manifest/incorrect.mf");
+        manifest = VFSUtils.readManifest(incorrectManifest);               
+        assertManifest(manifest);
+    }
+
+    private void assertManifest(Manifest manifest) {
+        Attributes attributes = manifest.getMainAttributes();
+        assertEquals(9, attributes.size());
+        assertEquals("Manifest-Version", "1.0", attributes.getValue("Manifest-Version"));
+        assertEquals("Specification-Title", "filesonly-war", attributes.getValue("Specification-Title"));
+        assertEquals("Specification-Version", "1.0.0.GA", attributes.getValue("Specification-Version"));
+        assertEquals("Specification-Vendor", "JBoss Inc.", attributes.getValue("Specification-Vendor"));
+        assertEquals("Implementation-Title", "filesonly-war", attributes.getValue("Implementation-Title"));
+        assertEquals("Implementation-URL", "http://www.jboss.org", attributes.getValue("Implementation-URL"));
+        assertEquals("Implementation-Version", "1.0.0.GA-jboss", attributes.getValue("Implementation-Version"));
+        assertEquals("Implementation-Vendor", "JBoss Inc.", attributes.getValue("Implementation-Vendor"));
+        assertEquals("Created-By", "${java.runtime.version} (${java.vendor})", attributes.getValue("Created-By"));
+    }
+
+    private void assertChildren(VirtualFile original, VirtualFile target) throws ArrayComparisonFailure, IOException {
+        assertEquals("Original and target must have the same numer of children", original.getChildren().size(), target.getChildren().size());
+        for (VirtualFile child : original.getChildren()) {
+            VirtualFile targetChild = target.getChild(child.getName());
+            assertTrue("Target should contain same children as original", targetChild.exists());
+            if (child.isDirectory()) {
+                assertChildren(child, targetChild);
+            } else {
+                assertContentEqual(child, targetChild);
+            }
+        }
+    }
 }

--- a/src/test/java/org/jboss/vfs/util/PaddedManifestStreamTest.java
+++ b/src/test/java/org/jboss/vfs/util/PaddedManifestStreamTest.java
@@ -1,0 +1,147 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2006, JBoss Inc., and individual contributors as indicated
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.vfs.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import org.jboss.vfs.VFSUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author ehsavoie
+ */
+public class PaddedManifestStreamTest {
+
+    public PaddedManifestStreamTest() {
+    }
+
+    /**
+     * Test of read method, of class PaddedManifestStream.
+     */
+    @Test
+    public void testReadUnpadded() throws Exception {
+        PaddedManifestStream input = new PaddedManifestStream(new ByteArrayInputStream("HelloWorld !".getBytes("UTF-8")));
+        ByteArrayOutputStream output = new ByteArrayOutputStream(15);
+        byte[] result = new byte[0];
+        try {
+            int c = 0;
+            while ((c = input.read()) != -1) {
+                output.write(c);
+            }
+            result = output.toByteArray();
+        } finally {
+            VFSUtils.safeClose(input);
+            VFSUtils.safeClose(output);
+        }
+        assertEquals("HelloWorld !\n", new String(result, "UTF-8"));
+    }
+
+    /**
+     * Test of read method, of class PaddedManifestStream.
+     */
+    @Test
+    public void testReadPadded() throws Exception {
+        PaddedManifestStream input = new PaddedManifestStream(new ByteArrayInputStream("HelloWorld !\n".getBytes("UTF-8")));
+        ByteArrayOutputStream output = new ByteArrayOutputStream(15);
+        byte[] result = new byte[0];
+        try {
+            int c = 0;
+            while ((c = input.read()) != -1) {
+                output.write(c);
+            }
+            result = output.toByteArray();
+        } finally {
+            VFSUtils.safeClose(input);
+            VFSUtils.safeClose(output);
+        }
+        assertEquals("HelloWorld !\n", new String(result, "UTF-8"));
+    }
+
+    @Test
+    public void testReadUnpaddedPadded() throws Exception {
+        PaddedManifestStream input = new PaddedManifestStream(new ByteArrayInputStream("HelloWorld !".getBytes("UTF-8")));
+        ByteArrayOutputStream output = new ByteArrayOutputStream(15);
+        byte[] result = new byte[0];
+        try {
+            int c = 0;
+            byte[] buffer = new byte[8];
+            while ((c = input.read(buffer)) != -1) {
+                output.write(buffer, 0, c);
+            }
+            result = output.toByteArray();
+        } finally {
+            VFSUtils.safeClose(input);
+            VFSUtils.safeClose(output);
+        }
+        assertEquals("HelloWorld !\n", new String(result, "UTF-8"));
+        input = new PaddedManifestStream(new ByteArrayInputStream("HelloWorld !".getBytes("UTF-8")));
+        output = new ByteArrayOutputStream(15);
+        try {
+            int c = 8;
+            byte[] buffer = new byte[8];
+            while ((c = input.read(buffer, 0, c)) != -1) {
+                output.write(buffer, 0, c);
+            }
+            result = output.toByteArray();
+        } finally {
+            VFSUtils.safeClose(input);
+            VFSUtils.safeClose(output);
+        }
+        assertEquals("HelloWorld !\n", new String(result, "UTF-8"));
+    }
+
+    @Test
+    public void testReadPaddedBulk() throws Exception {
+        PaddedManifestStream input = new PaddedManifestStream(new ByteArrayInputStream("HelloWorld !\n".getBytes("UTF-8")));
+        ByteArrayOutputStream output = new ByteArrayOutputStream(15);
+        byte[] result = new byte[0];
+        try {
+            int c = 0;
+            byte[] buffer = new byte[8];
+            while ((c = input.read(buffer)) != -1) {
+                output.write(buffer, 0, c);
+            }
+            result = output.toByteArray();
+        } finally {
+            VFSUtils.safeClose(input);
+            VFSUtils.safeClose(output);
+        }
+        assertEquals("HelloWorld !\n", new String(result, "UTF-8"));
+        input = new PaddedManifestStream(new ByteArrayInputStream("HelloWorld !".getBytes("UTF-8")));
+        output = new ByteArrayOutputStream(15);
+        try {
+            int c = 8;
+            byte[] buffer = new byte[8];
+            while ((c = input.read(buffer, 0, c)) != -1) {
+                output.write(buffer, 0, c);
+            }
+            result = output.toByteArray();
+        } finally {
+            VFSUtils.safeClose(input);
+            VFSUtils.safeClose(output);
+        }
+        assertEquals("HelloWorld !\n", new String(result, "UTF-8"));
+    }
+
+}

--- a/src/test/resources/vfs/test/manifest/correct.mf
+++ b/src/test/resources/vfs/test/manifest/correct.mf
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Created-By: ${java.runtime.version} (${java.vendor})
+Specification-Title: filesonly-war
+Specification-Version: 1.0.0.GA
+Specification-Vendor: JBoss Inc.
+Implementation-Title: filesonly-war
+Implementation-URL: http://www.jboss.org
+Implementation-Version: 1.0.0.GA-jboss
+Implementation-Vendor: JBoss Inc.
+

--- a/src/test/resources/vfs/test/manifest/incorrect.mf
+++ b/src/test/resources/vfs/test/manifest/incorrect.mf
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Created-By: ${java.runtime.version} (${java.vendor})
+Specification-Title: filesonly-war
+Specification-Version: 1.0.0.GA
+Specification-Vendor: JBoss Inc.
+Implementation-Title: filesonly-war
+Implementation-URL: http://www.jboss.org
+Implementation-Version: 1.0.0.GA-jboss
+Implementation-Vendor: JBoss Inc.


### PR DESCRIPTION
if this char is missing at the end of the file.
