### PR TITLE
WFLY-1547 Introduce an API on TempFileProvider which allows cleaning up existing content

### DIFF
--- a/src/main/java/org/jboss/vfs/TempDir.java
+++ b/src/main/java/org/jboss/vfs/TempDir.java
@@ -110,7 +110,7 @@ public final class TempDir implements Closeable {
      */
     public void close() throws IOException {
         if (open.getAndSet(false)) {
-            provider.new DeleteTask(root).run();
+            provider.delete();
         }
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-1547 raises an issue where temp content provided by TempFileProvider can stay around (for whatever valid reasons) on JVM exit. Leaving this content around across server reboots will obviously lead to disk space usage increase. The proposed solution is to clean this content upon server restart in a background thread (without affecting the normal boot timings) and at the same time ensure that the root directory represented by the TempFileProvider is usable without worrying about new content being added getting deleted by the background thread.

The commit here addresses these issues by introducing a new API:

```
/**
     * Create a temporary file provider for a given type.
     *
     * @param providerType The provider type string (used as a prefix in the temp file dir name)
     * @param executor Executor which will be used to manage temp file provider tasks (like cleaning up/deleting the temp files when needed)
     * @param cleanExisting If this is true, then existing temp content (if any) for the <code>providerType</code> will be deleted and the implementation ensures that when this method returns, the
     *                      returned {@link TempFileProvider} can be used and the previously existing content (if any) for this <code>providerType</code> will <i>not<i/> be present under the root directory
     *                      represented by the returned {@link TempFileProvider}
     * @return The new provider
     * @throws IOException if an I/O error occurs
     */
    public static TempFileProvider create(final String providerType, final ScheduledExecutorService executor, final boolean cleanExisting) throws IOException {
```
