### PR TITLE
Don't throw an exception if we run into trouble while cleaning existing temp content for provider

### DIFF
--- a/src/main/java/org/jboss/vfs/VFSLogger.java
+++ b/src/main/java/org/jboss/vfs/VFSLogger.java
@@ -1,13 +1,14 @@
 package org.jboss.vfs;
 
-import static org.jboss.logging.Logger.Level.WARN;
-
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+
+import static org.jboss.logging.Logger.Level.WARN;
+import static org.jboss.logging.Logger.Level.INFO;
 
 /**
  * @author Tomaz Cerar (c) 2013 Red Hat Inc.
@@ -25,5 +26,8 @@ public interface VFSLogger extends BasicLogger {
     @Message(id = 1, value = "A VFS mount (%s) was leaked!")
     void vfsMountLeaked(VirtualFile mountPoint, @Cause Throwable cause);
 
+    @LogMessage(level = INFO)
+    @Message(id = 2, value = "Failed to clean existing content for temp file provider of type %s. Enable DEBUG level log to find what caused this")
+    void failedToCleanExistingContentForTempFileProvider(String providerType);
 
 }

--- a/src/main/java/org/jboss/vfs/VFSMessages.java
+++ b/src/main/java/org/jboss/vfs/VFSMessages.java
@@ -28,8 +28,9 @@ public interface VFSMessages {
     @Message(id = 12, value = "Temp file provider closed")
     IOException tempFileProviderClosed();
 
-    @Message(id = 13, value = "Failed to clean existing content for temp file provider of type %s")
-    IOException failedToCleanExistingContentForTempFileProvider(String providerType);
+    //  Retired
+    //    @Message(id = 13, value = "Failed to clean existing content for temp file provider of type %s")
+    //    IOException failedToCleanExistingContentForTempFileProvider(String providerType);
 
     @Message(id = 14, value = "Could not create directory for root '%s' (prefix '%s', suffix '%s') after %d attempts")
     IOException couldNotCreateDirectoryForRoot(File root, String prefix, String suffix, int retries);


### PR DESCRIPTION
We recently introduced an API where the existing content (if any) of a temp provider would be cleaned up while creating a new temp provider for a specific type. This new API  was implemented to throw an exception if something goes wrong when _triggering_ a cleanup of the existing content. That previous implementation has shown that it can lead to an undesired behaviour of causing the server boot to fail.

The commit here changes the implementation to just log a message instead of throwing an error in such cases.
