### PR TITLE
[JBVFS-199] RealFileSystem:exists is not case sensitive in windows

### DIFF
--- a/src/main/java/org/jboss/vfs/spi/RealFileSystem.java
+++ b/src/main/java/org/jboss/vfs/spi/RealFileSystem.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jboss.vfs.VFSLogger;
+import org.jboss.vfs.VFSUtils;
 import org.jboss.vfs.VirtualFile;
 
 /**
@@ -168,10 +169,11 @@ public final class RealFileSystem implements FileSystem {
         final File file = getFile(mountPoint, target);
         return privileged ? doPrivileged(new PrivilegedAction<Boolean>() {
             public Boolean run() {
-                return Boolean.valueOf(file.exists());
+                return Boolean.valueOf(VFSUtils.exists(file));
             }
-        }).booleanValue() : file.exists();
+        }).booleanValue() : VFSUtils.exists(file);
     }
+
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
This leads to a compilation failure with undertow and jbossweb.
BZ 6.x: https://bugzilla.redhat.com/show_bug.cgi?id=1127999
