### PR TITLE
[BZ-1127999]  JBOSS JSP class loading problem due to case insensitivity

### DIFF
--- a/src/main/java/org/jboss/vfs/spi/RealFileSystem.java
+++ b/src/main/java/org/jboss/vfs/spi/RealFileSystem.java
@@ -74,7 +74,14 @@ public final class RealFileSystem implements FileSystem {
                 sm.checkPermission(new FilePermission(new File(realRoot, "-").getPath(), "read,delete"));
             }
         }
-        this.realRoot = realRoot;
+        // the transformation is for case insensitive file systems. This helps to ensure that the rest of the path matches exactly the canonical form
+        File canonicalRoot = realRoot;
+        try {
+            canonicalRoot = realRoot.getCanonicalFile();
+        } catch(IOException e) {
+            VFSLogger.ROOT_LOGGER.warnf(e, "Cannot get the canonical form of the real root. This could lead to potential problems if the %s flag is set.", VFSUtils.FORCE_CASE_SENSITIVE_KEY);
+        }
+        this.realRoot = canonicalRoot;
         this.privileged = privileged;
         VFSLogger.ROOT_LOGGER.tracef("Constructed real %s filesystem at root %s", privileged ? "privileged" : "unprivileged", realRoot);
     }


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1127999
Jira: https://issues.jboss.org/browse/JBVFS-199

realRoot must be canonical. When getFile is invoked and the 
realRoot provided is not the exact match the vfs creates a 
non-canonical form of the file. This could lead when the flag
-Djboss.vfs.forceCaseSensitive=true is set to fail on windows.
(this happens when the realRoot comes from an env vars, i.e jboss.server.temp.dir)
