### PR TITLE
Don't use zipEntry timestamp for jsp files as jasper jsp compiler dep…

### DIFF
--- a/src/main/java/org/jboss/vfs/VFSUtils.java
+++ b/src/main/java/org/jboss/vfs/VFSUtils.java
@@ -908,7 +908,9 @@ public class VFSUtils {
                     } finally {
                         VFSUtils.safeClose(is);
                     }
-                    current.setLastModified(zipEntry.getTime());
+                    // exclude jsp files last modified time change. jasper jsp compiler Compiler.java depends on last modified time-stamp to re-compile jsp files
+                    if (!current.getName().endsWith(".jsp"))
+                        current.setLastModified(zipEntry.getTime());
                 }
             }
         } finally {


### PR DESCRIPTION
…ends on last modified time-stamp to re-compile jsp file.

commit https://github.com/jbossas/jboss-vfs/commit/c21a0ed4105c4e6c1e1ac772167aa069a8d1e5b9 set file modification times when unzipping archives. 
This should not include jsp files, otherwise, the variable value of jspRealLastModified is stale modification time of the zipEntry at https://source.jboss.org/browse/JBossWeb/branches/7.5.x/src/main/java/org/apache/jasper/compiler/Compiler.java?hb=true#to468

This leads to wrong result in comment 4 of https://bugzilla.redhat.com/show_bug.cgi?id=1223081