### PR TITLE
JBVFS-206 VirtualFileURLConnection#getContent() doesn't call a conten…

### DIFF
--- a/src/main/java/org/jboss/vfs/protocol/VirtualFileURLConnection.java
+++ b/src/main/java/org/jboss/vfs/protocol/VirtualFileURLConnection.java
@@ -45,7 +45,10 @@ class VirtualFileURLConnection extends AbstractURLConnection {
     public void connect() throws IOException {
     }
 
-    public VirtualFile getContent() throws IOException {
+    public Object getContent() throws IOException {
+        if (getContentType() != null) {
+            return super.getContent();
+        }
         return file;
     }
 


### PR DESCRIPTION
…t handler

...determined by connection's contentType

https://issues.jboss.org/browse/JBVFS-206
https://issues.jboss.org/browse/JBEAP-15028