### PR TITLE
JBVFS-207 Provide way to retrieve VirtualFile instance from url.openConnection()

### DIFF
--- a/src/main/java/org/jboss/vfs/protocol/VirtualFileURLConnection.java
+++ b/src/main/java/org/jboss/vfs/protocol/VirtualFileURLConnection.java
@@ -76,4 +76,18 @@ class VirtualFileURLConnection extends AbstractURLConnection {
     protected String getName() {
         return file.getName();
     }
+
+    @Override
+    public Object getContent(Class[] classes) throws IOException {
+        Object obj = super.getContent(classes);
+
+        for (int i = 0; i < classes.length; i++) {
+            if (classes[i] == VirtualFile.class) {
+                return file;
+            } else if (classes[i].isInstance(obj)) {
+                return obj;
+            }
+        }
+        return obj;
+    }
 }

--- a/src/test/java/org/jboss/test/vfs/URLConnectionUnitTestCase.java
+++ b/src/test/java/org/jboss/test/vfs/URLConnectionUnitTestCase.java
@@ -20,6 +20,7 @@ package org.jboss.test.vfs;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -34,6 +35,7 @@ import org.jboss.vfs.VFSUtils;
 import org.jboss.vfs.VirtualFile;
 import org.jboss.vfs.protocol.FileURLConnection;
 import org.jboss.vfs.protocol.VfsUrlStreamHandlerFactory;
+import org.junit.Assert;
 
 /**
  * Basic tests of URL connection
@@ -80,6 +82,19 @@ public class URLConnectionUnitTestCase extends AbstractVFSTest {
         URL url = getURLAndAssertProtocol(file);
         URLConnection conn = url.openConnection();
         assertEquals(file, conn.getContent());
+    }
+
+    public void testGetContentWithType() throws Exception {
+        VirtualFile file = getVirtualFile("/vfs/test/test-web.xml");
+        URL url = getURLAndAssertProtocol(file);
+        URLConnection conn = url.openConnection();
+
+        Assert.assertTrue(conn.getContent() instanceof FileInputStream); // handled by UnknownContentHandler
+        Assert.assertTrue(conn.getContent(new Class[]{VirtualFile.class}) instanceof VirtualFile);
+        Assert.assertTrue(conn.getContent(new Class[]{FileInputStream.class, VirtualFile.class}) instanceof FileInputStream);
+        Assert.assertTrue(conn.getContent(new Class[]{VirtualFile.class, FileInputStream.class}) instanceof VirtualFile);
+        Assert.assertTrue(conn.getContent(new Class[]{SomeClass.class, VirtualFile.class}) instanceof VirtualFile);
+        Assert.assertNull(conn.getContent(new Class[]{SomeClass.class}));
     }
 
     /**
@@ -235,4 +250,6 @@ public class URLConnectionUnitTestCase extends AbstractVFSTest {
         }
         return baos.toByteArray();
     }
+
+    private static class SomeClass {}
 }


### PR DESCRIPTION
JBEAP: https://issues.jboss.org/browse/JBEAP-16103
WFLY: https://issues.jboss.org/browse/WFLY-11567
Upstream Jira: https://issues.jboss.org/projects/JBVFS/issues/JBVFS-207
Upstream PR: https://github.com/jbossas/jboss-vfs/pull/30

E.g. Drools [1] needs to get an instance of VirtualFile from URL#openConnection(), but after #28 there's no way to retrieve it.

[1] kiegroup/drools@2a36f67