### PR TITLE
[JBEAP-22921] Delay openStream call for each entry in VirtualJarInputStream

### DIFF
--- a/src/main/java/org/jboss/vfs/VirtualJarInputStream.java
+++ b/src/main/java/org/jboss/vfs/VirtualJarInputStream.java
@@ -50,6 +50,7 @@ public class VirtualJarInputStream extends JarInputStream {
     private final Deque<Iterator<VirtualFile>> entryItr = new ArrayDeque<Iterator<VirtualFile>>();
     private final VirtualFile root;
     private final Manifest manifest;
+    private VirtualFile currentVirtualFile = null;
     private InputStream currentEntryStream = VFSUtils.emptyStream();
     private boolean closed;
 
@@ -172,6 +173,7 @@ public class VirtualJarInputStream extends JarInputStream {
      */
     @Override
     public void closeEntry() throws IOException {
+        currentVirtualFile = null;
         if (currentEntryStream != null) {
             currentEntryStream.close();
         }
@@ -192,6 +194,13 @@ public class VirtualJarInputStream extends JarInputStream {
     private void ensureOpen() throws IOException {
         if (closed) {
             throw VFSMessages.MESSAGES.streamIsClosed();
+        }
+        if (currentEntryStream == null) {
+            if (currentVirtualFile != null) {
+                currentEntryStream = currentVirtualFile.openStream();
+            } else {
+                currentEntryStream = VFSUtils.emptyStream();
+            }
         }
     }
 
@@ -218,9 +227,11 @@ public class VirtualJarInputStream extends JarInputStream {
      */
     private void openCurrent(VirtualFile current) throws IOException {
         if (current.isDirectory()) {
+            currentVirtualFile = null;
             currentEntryStream = VFSUtils.emptyStream();
         } else {
-            currentEntryStream = current.openStream();
+            currentVirtualFile = current;
+            currentEntryStream = null;
         }
     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-22921

Just delaying the call to `openStream` in `VirtualJarInputStream` until a method that really needs the entry stream is invoked. The open is now done in the method `ensureOpen` because it's always called in the required methods. A new test is added to check that iteration with read continue working as expected.

PR for master.
PR for 3.2: https://github.com/jbossas/jboss-vfs/pull/39