### PR TITLE
 WFLY-16322 Ensure proper handling of content type availability in VirtualFileURLConnection (3.2.17) 

### DIFF
--- a/src/main/java/org/jboss/vfs/protocol/VirtualFileURLConnection.java
+++ b/src/main/java/org/jboss/vfs/protocol/VirtualFileURLConnection.java
@@ -35,6 +35,8 @@ import org.jboss.vfs.VirtualFile;
  * @version $Revision: 1.1 $
  */
 class VirtualFileURLConnection extends AbstractURLConnection {
+    static final String JAR_CONTENT_TYPE = "application/java-archive";
+
     private final VirtualFile file;
 
     VirtualFileURLConnection(URL url) throws IOException {
@@ -46,10 +48,10 @@ class VirtualFileURLConnection extends AbstractURLConnection {
     }
 
     public Object getContent() throws IOException {
-        if (getContentType() != null) {
-            return super.getContent();
+        if (JAR_CONTENT_TYPE.equals(getContentType()) || getContentType() == null) {
+            return file;
         }
-        return file;
+        return super.getContent();
     }
 
     public int getContentLength() {

--- a/src/test/java/org/jboss/vfs/protocol/VirtualFileURLConnectionTest.java
+++ b/src/test/java/org/jboss/vfs/protocol/VirtualFileURLConnectionTest.java
@@ -1,0 +1,92 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2006, JBoss Inc., and individual contributors as indicated
+* by the @authors tag.
+*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.jboss.vfs.protocol;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import junit.framework.TestSuite;
+import org.jboss.test.vfs.AbstractVFSTest;
+import org.jboss.vfs.VirtualFile;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Provides test cases for WFLY16322, which was broken in
+ * <a href="https://bugs.openjdk.java.net/browse/JDK-8273655">JDK-8273655
+ * content-types.properties files are missing some common types</a>
+ * and released in 17.0.3, 11.0.16, 13.0.12 and 15.0.8. The JDK issue implements
+ * a content type for Java Archives, which breaks the expectation that
+ * getContent() returns the VirtualFile (behavior for when the content type is
+ * {@code null}.
+ */
+public class VirtualFileURLConnectionTest extends AbstractVFSTest {
+    public VirtualFileURLConnectionTest(String name) {
+        super(name);
+    }
+
+    public static junit.framework.Test suite() {
+        return new TestSuite(VirtualFileURLConnectionTest.class);
+    }
+
+    @Test
+    public void testFixWFLY16322ContentTypeJarShouldReturnVirtualFile() throws MalformedURLException, IOException {
+        VirtualFile jar = getVirtualFile("/vfs/test/dup.jar");
+
+        URL url = getResource("/vfs/test/dup.jar");
+        VirtualFileURLConnection con = new VirtualFileURLConnection(url) {
+            public String getContentType() {
+                return VirtualFileURLConnection.JAR_CONTENT_TYPE;
+            }
+        };
+
+        Object content = con.getContent();
+        Assert.assertTrue(content instanceof VirtualFile);
+    }
+
+    @Test
+    public void testFixWFLY16322NullValueShouldReturnVirtualFile() throws MalformedURLException, IOException {
+        VirtualFile jar = getVirtualFile("/vfs/test/dup.jar");
+
+        URL url = getResource("/vfs/test/dup.jar");
+        VirtualFileURLConnection con = new VirtualFileURLConnection(url) {
+            public String getContentType() {
+                return null;
+            }
+        };
+
+        Object content = con.getContent();
+        Assert.assertTrue(content instanceof VirtualFile);
+    }
+
+    @Test
+    public void testFixWFLY16322ContentTypeJsonShouldReturnFileInputStream() throws MalformedURLException, IOException {
+        VirtualFile jar = getVirtualFile("/vfs/test/dup.jar");
+
+        URL url = getResource("/vfs/test/dup.jar");
+        VirtualFileURLConnection con = new VirtualFileURLConnection(url) {
+            public String getContentType() {
+                return "application/json";
+            }
+        };
+
+        Object content = con.getContent();
+        Assert.assertTrue(content instanceof FileInputStream);
+    }
+}


### PR DESCRIPTION
This is a PR for merging the master fix into the 3.2 branch. It should apply
cleanly.

Link to ticket: https://issues.redhat.com/browse/WFLY-16322

In the JDK 17.0.3 release (and other releases, i.e. 11.0.16, 13.0.12,
15.0.8)), the backport of "JDK-8273655 content-types.properties files
are missing some common types" breaks VFS in VirtualFileUrlConnnection.

Instead of returning the VirtualFile as expected (i.e. previous behavior
prior to JDK-8274655) it now returns the input stream from the super
class, causing issues in client libraries that depend on getting a
VirtualFile.

This commit retains the old behavior, and introduces a check for the
content type "application/java-archive" as specified in JDK-8273655's
properties files.

(cherry picked from commit cc9bac27ce0d303eaf4aefa9d3bafecf3287db62,
applied formatting fixes for check style)