### PR TITLE
correct license name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <licenses>
         <license>
-            <name>asl</name>
+            <name>Apache License 2.0</name>
             <url>http://repository.jboss.org/licenses/apache-2.0.txt</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
If this ever gets updated I'd like it to have an unambiguous license name, WildFly consumes this project and we rely on this info.