### PR TITLE
[JBVFS-223] Introducing VfsUrlStreamHandlerProvider as replacement for VfsUrlStreamHandlerFactory.

### DIFF
--- a/src/main/java/org/jboss/vfs/protocol/VfsUrlStreamHandlerProvider.java
+++ b/src/main/java/org/jboss/vfs/protocol/VfsUrlStreamHandlerProvider.java
@@ -18,18 +18,16 @@
 package org.jboss.vfs.protocol;
 
 import java.net.URLStreamHandler;
-import java.net.URLStreamHandlerFactory;
+import java.net.spi.URLStreamHandlerProvider;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * URLStreamHandlerFactory providing URLStreamHandlers for VFS based URLS.
+ * URLStreamHandlerProvider providing URLStreamHandlers for VFS based URLs.
  *
- * @author John Bailey
- * @deprecated Use {@link VfsUrlStreamHandlerProvider} instead.
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
-@Deprecated(forRemoval = true)
-public class VfsUrlStreamHandlerFactory implements URLStreamHandlerFactory {
+public final class VfsUrlStreamHandlerProvider extends URLStreamHandlerProvider {
 
     private static Map<String, URLStreamHandler> handlerMap = new HashMap<String, URLStreamHandler>(1);
 

--- a/src/main/resources/META-INF/services/java.net.spi.URLStreamHandlerProvider
+++ b/src/main/resources/META-INF/services/java.net.spi.URLStreamHandlerProvider
@@ -1,0 +1,1 @@
+org.jboss.vfs.protocol.VfsUrlStreamHandlerProvider


### PR DESCRIPTION
https://issues.redhat.com/browse/JBVFS-223
